### PR TITLE
Allow other modules to alter the amp converter.

### DIFF
--- a/amp.api.php
+++ b/amp.api.php
@@ -34,3 +34,12 @@ function hook_is_amp_request_alter(&$result) {
 function hook_amp_metadata_alter(&$metadata_json, $node, $type) {
 
 }
+
+/**
+ * Allow other modules to alter the amp converter.
+ *
+ * @param Lullabot\AMP\AMP
+ */
+function hook_amp_converter_alter($amp) {
+
+}

--- a/amp.module
+++ b/amp.module
@@ -1243,7 +1243,9 @@ function _amp_get_layouts() {
  * @return AMP
  */
 function _amp_create_amp_converter() {
-  return new AMP();
+  $amp = new AMP();
+  drupal_alter('amp_converter', $amp);
+  return $amp;
 }
 
 


### PR DESCRIPTION
Allow other modules to alter the amp converter created in `_amp_create_amp_converter();`

Issue created: https://www.drupal.org/project/amp/issues/2941421